### PR TITLE
--streaming option

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ For more details about tokens, visit [Slack's API page](https://api.slack.com/).
 
 ```
 webhook_url=""      # Incoming Webhooks integration URL. See https://my.slack.com/services/new/incoming-webhook
-upload_token=""     # The user's API authentication token, only used for file uploads. See https://api.slack.com/#auth
+token=""            # The user's API authentication token, only used for file uploads and streaming. See https://api.slack.com/#auth
 channel=""          # Default channel to post messages. '#' is prepended, if it doesn't start with '#' or '@'.
 tmp_dir="/tmp"      # Temporary file is created in this directory.
 username="slacktee" # Default username to post messages.
@@ -87,6 +87,7 @@ usage: slacktee.sh [options]
   options:
     -h, --help                        Show this help.
     -n, --no-buffering                Post input values without buffering.
+    --streaming                       Post input as it comes in, and update one comment with further input.
     -f, --file                        Post input values as a file.
     -l, --link                        Add a URL link to the message.
     -c, --channel channel_name        Post input values to specified channel or user.
@@ -182,7 +183,7 @@ plaintext values inside your slacktee.conf file.
 
 Instead, use the [encrypt command](https://github.com/travis-ci/travis.rb#encrypt)
 of the Travis client to set the SLACKTEE\_WEBHOOK and SLACKTEE\_TOKEN
-environment variables, and leave the *webhook_url* and *upload_token* values
+environment variables, and leave the *webhook_url* and *token* values
 in your slacktee.conf empty. When *slacktee* runs, it will give priority to the
 environment variables, which Travis-CI will decrypt and set automatically during
 the build process. In this way those two values are kept secure.
@@ -192,7 +193,7 @@ the build process. In this way those two values are kept secure.
 Modify slacktee.conf
 ```
 webhook_url=""
-upload_token=""
+token=""
 channel="Travis-CI"
 tmp_dir="/tmp"
 username="slacktee"

--- a/slacktee.conf
+++ b/slacktee.conf
@@ -5,7 +5,7 @@
 #   NOTE : Please rename this file to '.slacktee', if you'd like to place this in your home directory.
 # ----------
 webhook_url=""      # Incoming Webhooks integration URL. See https://my.slack.com/services/new/incoming-webhook
-upload_token=""     # The user's API authentication token, only used for file uploads. See https://api.slack.com/#auth
+token=""            # The user's API authentication token, only used for file uploads or streaming. See https://api.slack.com/#auth
 channel=""          # Default channel to post messages. '#' is prepended, if it doesn't start with '#' or '@'.
 tmp_dir="/tmp"      # Temporary file is created in this directory.
 username="slacktee" # Default username to post messages.

--- a/slacktee.sh
+++ b/slacktee.sh
@@ -281,22 +281,13 @@ function process_line()
 				send_message "$text"
 				text="$line"
 			else
-				if [[ $textWrapper == "\`\`\`" ]]; then
-					text="$text\n$line"
-				else
-					text=$(printf '%s\n%s' "$text" "$line")
-				fi
+				text=$(printf '%s\n%s' "$text" "$line")
 			fi
 		fi
 	elif [[ $mode == "streaming" ]]; then
 		if [[ -z "$text" ]]; then
 			text="$line"
 		else
-			# if [[ $textWrapper == "\`\`\`" ]]; then
-			# 	text="$text\n$line"
-			# else
-			# 	text=$(printf '%s\n%s' "$text" "$line")
-			# fi
 			text=$(printf '%s\n%s' "$text" "$line")
 		fi
 

--- a/slacktee.sh
+++ b/slacktee.sh
@@ -23,7 +23,7 @@
 # Default Configuration
 # ----------
 webhook_url=""       # Incoming Webhooks integration URL
-upload_token=""      # The user's API authentication token, only used for file uploads
+token=""             # The user's API authentication token, only used for file uploads or streaming
 channel="general"    # Default channel to post messages. '#' is prepended, if it doesn't start with '#' or '@'.
 tmp_dir="/tmp"       # Temporary file is created in this directory.
 username="slacktee"  # Default username to post messages.
@@ -82,6 +82,7 @@ Usage: $me [options]
 options:
     -h, --help                        Show this help.
     -n, --no-buffering                Post input values without buffering.
+    --streaming                       Post input as it comes in, and update one comment with further input.
     -f, --file                        Post input values as a file.
     -l, --link                        Add a URL link to the message.
     -c, --channel channel_name        Post input values to specified channel or user.
@@ -109,8 +110,6 @@ options:
 EOF
 }
 
-
-
 function send_message()
 {
 	message="$1"
@@ -122,7 +121,7 @@ function send_message()
 		found_pattern_prefix=""
 	fi
 
-	wrapped_message=$(echo "$textWrapper\n$message\n$textWrapper")
+	wrapped_message=$(printf '%s\n%s\n%s' "$textWrapper" "$message" "$textWrapper")
 	message_attr=""
 	if [[ $message != "" ]]; then
 		if [[ -n $attachment ]]; then
@@ -193,22 +192,41 @@ function send_message()
 
 		username=$(escape_string "$username")
 
-		json="{\
-                  \"channel\": \"$channel\", \
-                  \"username\": \"$username\", \
-                  $message_attr \"icon_emoji\": \"$icon_emoji\", \
-                  \"icon_url\": \"$icon_url\" $parseMode}"
-		post_result=$(curl -X POST --data-urlencode \
-                  "payload=$json" "$webhook_url" 2> /dev/null)
-                if [[ $post_result != "ok" ]]; then
-                	err_exit 1 "$post_result"
-                fi
+		if [[ $mode == "streaming" ]]; then
+			if [[ -z "$streaming_ts" ]]; then
+				post_result=$(curl -d "token=$token&username=$username&icon_url=$icon_url&icon_emoji=$icon_emoji&$parseModeUrlEncoded&channel=$channel&text=$wrapped_message" -X POST https://slack.com/api/chat.postMessage 2> /dev/null)
+				if [ $? != 0 ]; then
+			    err_exit 1 "$post_result"
+				fi
+
+				# chat.update requires the channel id, not the name
+				streaming_channel_id=$(echo "$post_result" | python -c "import sys, json; print json.load(sys.stdin)['channel']")
+				
+				# timestamp is used as the message id
+				streaming_ts=$(echo "$post_result" | python -c "import sys, json; print json.load(sys.stdin)['ts']")
+			else
+				post_result=$(curl -d "token=$token&channel=$streaming_channel_id&ts=$streaming_ts&text=$wrapped_message" -X POST https://slack.com/api/chat.update 2> /dev/null)
+				if [ $? != 0 ]; then
+			    err_exit 1 "$post_result"
+				fi
+			fi
+		else
+			json="{\
+	                  \"channel\": \"$channel\", \
+	                  \"username\": \"$username\", \
+	                  $message_attr \"icon_emoji\": \"$icon_emoji\", \
+	                  \"icon_url\": \"$icon_url\" $parseMode}"
+			post_result=$(curl -X POST --data-urlencode \
+	                  "payload=$json" "$webhook_url" 2> /dev/null)
+	                if [[ $post_result != "ok" ]]; then
+	                	err_exit 1 "$post_result"
+	                fi
+		fi
 	fi
 }
 
 function process_line()
 {
-
 	# do not print message / line if -q option is specified
 	if [[ "$no_output" == "" ]]; then
 		echo "$1"
@@ -253,7 +271,7 @@ function process_line()
 	elif [[ $mode == "file" ]]; then
 		# We should use unescaped value in the file mode
 		echo "$1" >> "$filename"
-	else
+	elif [[ $mode == "buffering" ]]; then
 		if [[ -z "$text" ]]; then
 			text="$line"
 		else
@@ -263,10 +281,29 @@ function process_line()
 				send_message "$text"
 				text="$line"
 			else
-				text="$text\n$line"
+				if [[ $textWrapper == "\`\`\`" ]]; then
+					text="$text\n$line"
+				else
+					text=$(printf '%s\n%s' "$text" "$line")
+				fi
 			fi
-		fi  
-	fi  
+		fi
+	elif [[ $mode == "streaming" ]]; then
+		if [[ -z "$text" ]]; then
+			text="$line"
+		else
+			# if [[ $textWrapper == "\`\`\`" ]]; then
+			# 	text="$text\n$line"
+			# else
+			# 	text=$(printf '%s\n%s' "$text" "$line")
+			# fi
+			text=$(printf '%s\n%s' "$text" "$line")
+		fi
+
+		send_message "$text"
+	else
+		err_exit 1 "Invalid mode: $mode."
+	fi
 }
 
 function setup()
@@ -329,9 +366,9 @@ function setup()
 	if [[ -z "$input_webhook_url" ]]; then
 		input_webhook_url=$webhook_url
 	fi
-	read -p "Upload Token [$upload_token]: " input_upload_token
-	if [[ -z "$input_upload_token" ]]; then
-		input_upload_token=$upload_token
+	read -p "Token [$token]: " input_token
+	if [[ -z "$input_token" ]]; then
+		input_token=$token
 	fi
 	read -p "Temporary Directory [$tmp_dir]: " input_tmp_dir
 	if [[ -z "$input_tmp_dir" ]]; then
@@ -358,7 +395,7 @@ function setup()
 
 	cat <<- EOF | sed 's/^[[:space:]]*//' > "$local_conf"
 	webhook_url="$input_webhook_url"
-	upload_token="$input_upload_token"
+	token="$input_token"
 	tmp_dir="$input_tmp_dir"
 	channel="$input_channel"
 	username="$input_username"
@@ -383,6 +420,9 @@ function parse_args()
 				;;
 			-n|--no-buffering)
 				mode="no-buffering"
+				;;
+			--streaming)
+				mode="streaming"
 				;;
 			-f|--file)
 				mode="file"
@@ -441,12 +481,15 @@ function parse_args()
 				case "$1" in
 					none)
 						parseMode=', "parse": "none"'
+						parseModeUrlEncoded='parse=none'
 						;;
 					link_names)
 						parseMode=', "link_names": "1"'
+						parseModeUrlEncoded='link_names=1'
 						;;
 					full)
 						parseMode=', "parse": "full"'
+						parseModeUrlEncoded='parse=full'
 						;;
 					*)
 						err_exit 1 "Unknown message formatting option."
@@ -559,6 +602,11 @@ function setup_environment()
 		. /etc/slacktee.conf
 	fi
 
+	# backwards compat
+	if [[ -z "$token" ]]; then
+		token="$upload_token"
+	fi
+
 	if [[ -n "$HOME" && -e "$HOME/.slacktee" ]]; then
 		. "$HOME/.slacktee"
 	fi
@@ -574,7 +622,7 @@ function setup_environment()
 
 	# Overwrite upload_token if the environment variable SLACKTEE_TOKEN is set
 	if [[ "$SLACKTEE_TOKEN" != "" ]]; then
-		upload_token="$SLACKTEE_TOKEN"
+		token="$SLACKTEE_TOKEN"
 	fi
 
 	# Overwrite channel if it's specified in the command line option
@@ -616,8 +664,12 @@ function check_configuration()
 		err_exit 1 "Please setup the webhook url of this incoming webhook integration."
 	fi
 
-	if [[ $upload_token == "" && $mode == "file" ]]; then
+	if [[ $token == "" && $mode == "file" ]]; then
 		err_exit 1 "Please provide the authentication token for file uploads."
+	fi
+
+	if [[ $token == "" && $mode == "streaming" ]]; then
+		err_exit 1 "Please provide the authentication token for streaming."
 	fi
 
 	if [[ $channel == "" ]]; then
@@ -703,7 +755,7 @@ function main()
 				# Set channels for making the file public
 				channels_param="-F channels=$channel"
 			fi
-			result="$(curl -F file=@"$filename" -F token="$upload_token" $channels_param https://slack.com/api/files.upload 2> /dev/null)"
+			result="$(curl -F file=@"$filename" -F token="$token" $channels_param https://slack.com/api/files.upload 2> /dev/null)"
 			access_url="$(echo "$result" | awk 'match($0, /url_private":"([^"]*)"/) {print substr($0, RSTART+14, RLENGTH-15)}'|sed 's/\\//g')"
 			download_url="$(echo "$result" | awk 'match($0, /url_private_download":"([^"]*)"/) {print substr($0, RSTART+23, RLENGTH-24)}'|sed 's/\\//g')"
 			if [[ -n "$attachment" ]]; then

--- a/test/test.sh
+++ b/test/test.sh
@@ -158,6 +158,13 @@ cat $DATA | $SLACKTEE '-q' '-t' 'Suppress the standard output (-q)'
 echo "-- Suppress the standard output (--no-output) --"
 cat $DATA | $SLACKTEE '--no-output' '-t' 'Suppress the standard output (--no-output)'
 
+# Test 19: Streaming output to single comment
+{
+  echo "let's count to 5"
+  for i in {1..5}; do
+    echo $i
+    sleep 1
+  done
+} | $SLACKTEE --streaming
+
 echo "Test is done!"
-
-


### PR DESCRIPTION
# usage

```
(echo "let's count to 5"; for i in {1..5}; do; echo $i && sleep 1; done) | ./slacktee.sh --streaming -c connor-test-channel
```

![slacktee-streaming](https://user-images.githubusercontent.com/4071474/42797148-a0b68ed2-8942-11e8-9e17-aad271da3296.gif)

# implementation

Couldn't use the webhook api, must use the regular api.

I noticed that the "\n" between long messages / inserting around the text wrapper will sometimes showing as a literal "\n" when added to the output (for example, during plain text mode for a really long message). I changed that to emit an actual new line ASCII character instead.

## Links
https://webapps.stackexchange.com/questions/73280/update-message-submitted-via-incoming-webhook-in-slack-com-api
https://api.slack.com/methods/chat.postMessage
https://api.slack.com/methods/chat.update