### PR TITLE
Fix bugs with --streaming option

### DIFF
--- a/slacktee.sh
+++ b/slacktee.sh
@@ -203,7 +203,6 @@ function send_message()
 					\"icon_url\": \"$icon_url\" $parseMode}"
 
 				post_result=$(curl -H "Authorization: Bearer $token" -H 'Content-type: application/json; charset=utf-8' -X POST -d "$json" https://slack.com/api/chat.postMessage 2> /dev/null)
-				# post_result=$(curl -d "token=$token&username=$username&icon_url=$icon_url&icon_emoji=$icon_emoji&$parseModeUrlEncoded&channel=$channel&text=$wrapped_message" -X POST https://slack.com/api/chat.postMessage 2> /dev/null)
 				if [ $? != 0 ]; then
 					err_exit 1 "$post_result"
 				fi
@@ -225,7 +224,6 @@ function send_message()
 						$parseMode}"
 
 					post_result=$(curl -H "Authorization: Bearer $token" -H 'Content-type: application/json; charset=utf-8' -X POST -d "$json" https://slack.com/api/chat.update 2> /dev/null)
-					# post_result=$(curl -d "token=$token&channel=$streaming_channel_id&ts=$streaming_ts&text=$wrapped_message" -X POST https://slack.com/api/chat.update 2> /dev/null)
 					if [ $? != 0 ]; then
 						err_exit 1 "$post_result"
 					fi

--- a/test/test.sh
+++ b/test/test.sh
@@ -186,4 +186,20 @@ cat $DATA | $SLACKTEE '--no-output' '-t' 'Suppress the standard output (--no-out
   echo 42
 } | $SLACKTEE --streaming --streaming-batch-time 2
 
+# Test 22: Streaming mode - test payload is properly escaped
+echo "hello ampersand &, equals =, quote ', and double quote \", please don't break my payload." | $SLACKTEE --streaming --streaming-batch-time 2
+
+# Test 23: Newlines show correctly
+echo -e "--streaming line one\n\nline three" | $SLACKTEE --streaming
+echo -e "--streaming -p line one\n\nline three" | $SLACKTEE --streaming -p
+echo -e "line one\n\nline three" | $SLACKTEE
+echo -e "-p line one\n\nline three" | $SLACKTEE -p
+
+# Test 24: Long messages
+long_message=$(printf '.%.0s' {1..5000})
+echo $long_message | $SLACKTEE -p # should be split up over two messages
+# these do not work correctly. Fixing seems complicated, and it's an edge case, so let's just document it here
+# echo $long_message | $SLACKTEE --streaming
+# echo $long_message | $SLACKTEE
+
 echo "Test is done!"

--- a/test/test.sh
+++ b/test/test.sh
@@ -167,4 +167,23 @@ cat $DATA | $SLACKTEE '--no-output' '-t' 'Suppress the standard output (--no-out
   done
 } | $SLACKTEE --streaming
 
+# Test 20: Streaming batches updates
+{
+  echo "let's count to 20, quickly!"
+  for i in {1..20}; do
+    echo $i
+    sleep 0.1
+  done
+} | $SLACKTEE --streaming
+
+# Test 21: streaming-batch-time
+{
+  echo "The answer to life, the universe, and everything is"
+  for i in {1..20}; do
+    echo '.'
+    sleep 0.3
+  done
+  echo 42
+} | $SLACKTEE --streaming --streaming-batch-time 2
+
 echo "Test is done!"


### PR DESCRIPTION
I noticed a few things after using `--streaming` more:

1. Because the payload is url encoded, and the text is not escaped, characters like & and = break the message
2. An API request is sent to `https://slack.com/api/chat.update` for every line of output. This is wasteful if there is more output available, and makes messages with many newlines take longer than they should.

To fix 1, I switched to using a JSON payload. To fix 2, I only send an update once every second (default option, can override with `--streaming-batch-time`.

I noticed that some of the newline changes I made were only relevant to the URL encoded payload, so I reverted those changes.

Also, I see that very long lines break both the streaming and buffering modes. Fixing it would be kind of problematic, so I'm just going to leave a commented out bad test for documentation. 