### PR TITLE
Use chat.postMessage API for posting a message

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,10 +66,14 @@ Before start using *slacktee*, please set following variables in the script conf
 *slacktee* reads the global configuration (/etc/slacktee.conf) first, then reads your local configuration (~/.slacktee).
 You can set up your local configuration file using interactive setup mode (--setup option).
 
-In order to retrieve the bot token, you need to add a bot into your workspace through [Slack App Directory](https://cks-world.slack.com/apps/A0F7YS25R-bots).
-Once you add a bot, you can find 'API Token' in the configuration page of the bot.
+You would need an authentication token for `slacktee`. It could be generated in 2 ways:
 
-Most proper way to generate the bot token is [creating a Slack App](https://api.slack.com/slack-apps#creating_apps), but it's a little bit more complicated than adding a bot. If you go this path, give three [permission scopes](https://api.slack.com/docs/oauth-scopes)  `chat:write:bot`, `files:write:user` and `bot` to your app. Also, don't forget to create a bot user for your app. 
+1. Crate a Slack App (Preffered by Slack, but a bit complicated to setup)  
+Follow steps listed in [creating a Slack App](https://api.slack.com/slack-apps#creating_apps).  
+Next, create a bot user for your app, give the following 3 permissions to your app: `chat:write:bot`, `files:write:user` and `bot`. More information about the permission scopes can be found at [permission scopes](https://api.slack.com/docs/oauth-scopes).  
+At last, install the app to your workplace and get the token in 'OAuth & Permission' feature in the manage application page.
+2. Add a bot (Easy to setup, but Slack may remove it in future)  
+Add a bot into your workspace through [Slack App Directory](https://cks-world.slack.com/apps/A0F7YS25R-bots). You can now find 'API Token' in the configuration page of the bot.
 
 ```
 token=""            # The authentication token of the bot user. Used for accessing Slack APIs.

--- a/README.md
+++ b/README.md
@@ -66,11 +66,13 @@ Before start using *slacktee*, please set following variables in the script conf
 *slacktee* reads the global configuration (/etc/slacktee.conf) first, then reads your local configuration (~/.slacktee).
 You can set up your local configuration file using interactive setup mode (--setup option).
 
-For more details about tokens, visit [Slack's API page](https://api.slack.com/).
+In order to retrieve the bot token, you need to add a bot into your workspace through [Slack App Directory](https://cks-world.slack.com/apps/A0F7YS25R-bots).
+Once you add a bot, you can find 'API Token' in the configuration page of the bot.
+
+Most proper way to generate the bot token is [creating a Slack App](https://api.slack.com/slack-apps#creating_apps), but it's a little bit more complicated than adding a bot. If you go this path, give three [permission scopes](https://api.slack.com/docs/oauth-scopes)  `chat:write:bot`, `files:write:user` and `bot` to your app. Also, don't forget to create a bot user for your app. 
 
 ```
-webhook_url=""      # Incoming Webhooks integration URL. See https://my.slack.com/services/new/incoming-webhook
-token=""            # The user's API authentication token, only used for file uploads and streaming. See https://api.slack.com/#auth
+token=""            # The authentication token of the bot user. Used for accessing Slack APIs.
 channel=""          # Default channel to post messages. '#' is prepended, if it doesn't start with '#' or '@'.
 tmp_dir="/tmp"      # Temporary file is created in this directory.
 username="slacktee" # Default username to post messages.

--- a/slacktee.sh
+++ b/slacktee.sh
@@ -703,6 +703,11 @@ function check_configuration()
 		icon=${icon#:} # remove leading ':'
 		icon=${icon%:} # remove trailing ':'
 	fi
+
+	# Show deprecation warning
+	if [[ $webhook_url != "" ]]; then
+	    echo "$me: webhook_url is deprecated but still set. Recommend to remove it and use token instead." > /dev/null >&2
+	fi
 }
 
 # ----------

--- a/slacktee.sh
+++ b/slacktee.sh
@@ -22,8 +22,8 @@
 # ----------
 # Default Configuration
 # ----------
-webhook_url=""       # Incoming Webhooks integration URL
-token=""             # The user's API authentication token, only used for file uploads or streaming
+webhook_url=""       # Incoming Webhooks integration URL. Old way to interact with Slack. (Deprecated)
+token=""             # The authentication token of the bot user. Used for accessing Slack APIs.
 channel="general"    # Default channel to post messages. '#' is prepended, if it doesn't start with '#' or '@'.
 tmp_dir="/tmp"       # Temporary file is created in this directory.
 username="slacktee"  # Default username to post messages.
@@ -203,7 +203,8 @@ function send_message()
 					\"icon_url\": \"$icon_url\" $parseMode}"
 
 				post_result=$(curl -H "Authorization: Bearer $token" -H 'Content-type: application/json; charset=utf-8' -X POST -d "$json" https://slack.com/api/chat.postMessage 2> /dev/null)
-				if [ $? != 0 ]; then
+				post_ok="$(echo "$post_result" | awk 'match($0, /"ok":([^,}]+)/) {print substr($0, RSTART+5, RLENGTH-5)}')"
+				if [ $post_ok != "true" ]; then
 					err_exit 1 "$post_result"
 				fi
 
@@ -224,7 +225,8 @@ function send_message()
 						$parseMode}"
 
 					post_result=$(curl -H "Authorization: Bearer $token" -H 'Content-type: application/json; charset=utf-8' -X POST -d "$json" https://slack.com/api/chat.update 2> /dev/null)
-					if [ $? != 0 ]; then
+					post_ok="$(echo "$post_result" | awk 'match($0, /"ok":([^,}]+)/) {print substr($0, RSTART+5, RLENGTH-5)}')"
+					if [ $post_ok != "true" ]; then
 						err_exit 1 "$post_result"
 					fi
 				fi
@@ -235,10 +237,19 @@ function send_message()
 				\"username\": \"$username\", \
 				$message_attr \"icon_emoji\": \"$icon_emoji\", \
 				\"icon_url\": \"$icon_url\" $parseMode}"
-			post_result=$(curl -X POST --data-urlencode \
+			if [[ ! -z $webhook_url ]]; then
+			    # Prioritize the webhook_url for the backward compatibility
+			    post_result=$(curl -X POST --data-urlencode \
 										"payload=$json" "$webhook_url" 2> /dev/null)
-			if [[ $post_result != "ok" ]]; then
+			    if [[ $post_result != "ok" ]]; then
 				err_exit 1 "$post_result"
+			    fi
+			else
+			    post_result=$(curl -H "Authorization: Bearer $token" -H 'Content-type: application/json; charset=utf-8' -X POST -d "$json" https://slack.com/api/chat.postMessage 2> /dev/null)
+			    post_ok="$(echo "$post_result" | awk 'match($0, /"ok":([^,}]+)/) {print substr($0, RSTART+5, RLENGTH-5)}')"
+			    if [ $post_ok != "true" ]; then
+				err_exit 1 "$post_result"
+			    fi
 			fi
 		fi
 	fi
@@ -372,10 +383,6 @@ function setup()
 	. $local_conf
 
 	# Start setup
-	read -p "Incoming Webhook URL [$webhook_url]: " input_webhook_url
-	if [[ -z "$input_webhook_url" ]]; then
-		input_webhook_url=$webhook_url
-	fi
 	read -p "Token [$token]: " input_token
 	if [[ -z "$input_token" ]]; then
 		input_token=$token
@@ -404,7 +411,7 @@ function setup()
 	fi
 
 	cat <<- EOF | sed 's/^[[:space:]]*//' > "$local_conf"
-	webhook_url="$input_webhook_url"
+	webhook_url="$webhook_url"
 	token="$input_token"
 	tmp_dir="$input_tmp_dir"
 	channel="$input_channel"
@@ -674,8 +681,8 @@ function check_configuration()
 		err_exit 1 "curl is not installed. Please install it first."
 	fi
 
-	if [[ $webhook_url == "" ]]; then
-		err_exit 1 "Please setup the webhook url of this incoming webhook integration."
+	if [[ $webhook_url == "" && $token == "" ]]; then
+		err_exit 1 "Please setup the authentication token or the incoming webhook url."
 	fi
 
 	if [[ $token == "" && $mode == "file" ]]; then

--- a/slacktee.sh
+++ b/slacktee.sh
@@ -682,7 +682,7 @@ function check_configuration()
 	fi
 
 	if [[ $webhook_url == "" && $token == "" ]]; then
-		err_exit 1 "Please setup the authentication token or the incoming webhook url."
+		err_exit 1 "Please setup the authentication token or the incoming webhook url (deprecated)."
 	fi
 
 	if [[ $token == "" && $mode == "file" ]]; then


### PR DESCRIPTION
Add a logic to use `chat.postMessage` API to post a message to Slack if `webhook_url` is not set.
Now, webhook_url is deprecated and is not set in the interactive setup mode (`--setup`).
This is a backward compatible change and `slacktee` is still use and prioritize `webhook_url` if it's set.

This PR should fix issue #56.