### PR TITLE
Abort the process when SIGINT, SIGTERM and SIGKILL are notified

### DIFF
--- a/slacktee.sh
+++ b/slacktee.sh
@@ -83,7 +83,7 @@ function get_ok_in_response() {
 function handle_signal()
 {
     cleanup
-    err_exit 130 "Aborting"
+    err_exit 1 "Aborting"
 }    
 
 function cleanup() 

--- a/slacktee.sh
+++ b/slacktee.sh
@@ -80,6 +80,12 @@ function get_ok_in_response() {
     echo "$(echo "$response" | awk 'match($0, /"ok":([^,}]+)/) {print substr($0, RSTART+5, RLENGTH-5)}')"
 }
 
+function handle_signal()
+{
+    cleanup
+    err_exit 130 "Aborting"
+}    
+
 function cleanup() 
 {
 	[[ -f $filename ]] && rm "$filename"
@@ -737,7 +743,7 @@ function main()
 	parse_args "$@"
 	setup_environment
 	check_configuration
-        trap cleanup SIGINT SIGTERM SIGKILL
+	trap handle_signal SIGINT SIGTERM SIGKILL
 
 	text=""
 	if [[ -n "$title" || -n "$link" ]]; then


### PR DESCRIPTION
This PR is addressing the issue #64.
`slacktee.sh` trapped SIGINT, SIGTERM and SIGKILL signals, but didn't abort the process in the handler.
