### PR TITLE
Remove carriage returns to avoid sending error

### DIFF
--- a/slacktee.sh
+++ b/slacktee.sh
@@ -140,6 +140,9 @@ function send_message()
 {
 	message="$1"
 
+	# Remove carriage returns
+	message=`echo $message | tr -d '\r'`
+
 	# Its a blank message, ignore
 	if [[ $message == "-- $title --\n" ]]; then
 	    return

--- a/test/test.sh
+++ b/test/test.sh
@@ -2,8 +2,9 @@
 # - Test set of slacktee.sh -
 
 # Test settings
-SLACKTEE="/bin/bash ../slacktee.sh"
-DATA="./test_data.txt"
+TEST_DIR=`dirname ${BASH_SOURCE[0]}`
+SLACKTEE="/bin/bash ${TEST_DIR}/../slacktee.sh"
+DATA="${TEST_DIR}/test_data.txt"
 CHANNEL="sandbox"
 SUB_CHANNEL="sandbox2"
 
@@ -216,5 +217,8 @@ echo $long_message | $SLACKTEE -p # should be split up over two messages
 # these do not work correctly. Fixing seems complicated, and it's an edge case, so let's just document it here
 # echo $long_message | $SLACKTEE --streaming
 # echo $long_message | $SLACKTEE
+
+# Test 27: Carriage return should be removed
+echo -e "\rcarriage \rreturn\r" | $SLACKTEE
 
 echo "Test is done!"


### PR DESCRIPTION
Addresses the issue #75 : Removing carriage return characters from the message in order to avoid sending error
